### PR TITLE
disable no-did-mount-set-state

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,7 +1,7 @@
 {
   "ecmaFeatures": {
     "jsx": true
-  },e
+  },
 
   "plugins": [
     "react"

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,7 +1,7 @@
 {
   "ecmaFeatures": {
     "jsx": true
-  },
+  },e
 
   "plugins": [
     "react"
@@ -16,7 +16,7 @@
     "react/jsx-sort-props": 0,
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
-    "react/no-did-mount-set-state": 2,
+    "react/no-did-mount-set-state": 0,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": 0,
     "react/no-unknown-property": 2,


### PR DESCRIPTION
Often I'll find myself settting up my listeners for dispatched events in `componentDidMount` as inline functions, especially if it is as simple as a single `setState`.

Pulling these functions out to be on the `class` instead would resolve this issue, however,  it seems a bit overly verbose. 

Typically, I agree this rule is very useful for catching any cases where a user actually calls `setState` in `componentDidMount`, however, for me, its more often than not just an annoying false-positive,  easily 'routed-around' by just using `var self = this`.

Therefore,  I vote it be removed.
In the event this "typical" case does occur, `react` will complain very loudly with clear error messages.

Thoughts @jprichardson / anyone else?
