### PR TITLE
Disable react/wrap-multilines

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -24,6 +24,6 @@
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
     "react/sort-comp": 0,
-    "react/wrap-multilines": 2
+    "react/wrap-multilines": 0
   }
 }


### PR DESCRIPTION
This prevents standard from whining about needing parentheses around multi-line JSX ([react/wrap-multilines](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md)), such as in this case which currently fails:

``` js
let Hello = React.createClass({
  render () {
    return <div>
      <p>Hello {this.props.name}</p>
    </div>
  }
})
```

See #4.
