### PR TITLE
Disable react/no-unknown-property globally

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -20,7 +20,7 @@
     "react/no-did-mount-set-state": 0,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": 0,
-    "react/no-unknown-property": 2,
+    "react/no-unknown-property": 0,
     "react/prop-types": 2,
     "react/react-in-jsx-scope": 0,
     "react/self-closing-comp": 2,


### PR DESCRIPTION
Since JSX is intended to be used by various preprocessors (transpilers) to transform DOM tokens into standard ECMAScript and it's not a proposal to incorporate with the ECMAScript spec itself, the usage of unknown DOM properties should not be restricted.
