### PR TITLE
Enable react/jsx-no-bind

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -15,6 +15,7 @@
   ],
 
   "rules": {
+    "react/jsx-no-bind": 2,
     "react/no-did-update-set-state": 2,
     "react/no-unknown-property": 2,
     "react/prop-types": 2


### PR DESCRIPTION
I would like to propose enabling react/jsx-no-bind

The reasoning comes from this post: https://medium.com/@esamatti/react-js-pure-render-performance-anti-pattern-fb88c101332f#9bed

In short, code like this:

``` js
<div onClick={this._handleClick.bind(this)}></div>
```

``` js
<div onClick={() => console.log('Hello!'))}></div>
```

is a common anti-pattern and means a new function is created every time render is called, this is bad for garbage collection, but also break PureComponents as th equality check will evaluate to false every time.
