### PR TITLE
use require.resolve to make ESLint correct resolve to the dependent config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
-module.exports = require('./eslintrc.json')
+module.exports = Object.assign({ }, require('./eslintrc.json'), {
+  extends: [ require.resolve('eslint-config-standard-jsx') ]
+})


### PR DESCRIPTION
Although `eslint-config-standard-jsx` is a dependency, in my project ESLint does not discover it.
