### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ provided in `eslint-config-standard`.
 Here's how to install everything you need:
 
 ```bash
-npm install eslint-config-standard eslint-config-standard-react eslint-config-standard-jsx eslint-plugin-react
+npm install eslint-config-standard eslint-config-standard-react eslint-config-standard-jsx eslint-plugin-promise eslint-plugin-react eslint-plugin-standard
 ```
 
 Then, add this to your .eslintrc file:


### PR DESCRIPTION
The install command does not include the two peer dependencies of `eslint-config-standard`

After running the current install:

```
├── eslint-config-standard@5.3.5
├── eslint-config-standard-jsx@2.0.0
├── eslint-config-standard-react@3.0.0
├── UNMET PEER DEPENDENCY eslint-plugin-promise@>=1.0.8
├─┬ eslint-plugin-react@6.0.0
│ └── jsx-ast-utils@1.3.1
└── UNMET PEER DEPENDENCY eslint-plugin-standard@>=1.3.1
```
