### PR TITLE
Remove eslint-config-standard-jsx from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ provided in `eslint-config-standard`.
 Here's how to install everything you need:
 
 ```bash
-npm install eslint-config-standard eslint-config-standard-react eslint-config-standard-jsx eslint-plugin-promise eslint-plugin-react eslint-plugin-standard
+npm install eslint-config-standard eslint-config-standard-react eslint-plugin-promise eslint-plugin-react eslint-plugin-standard
 ```
 
 Then, add this to your .eslintrc file:


### PR DESCRIPTION
It is listed in `dependencies` and just -1 plugin to install when use `eslint-config-standard-react` directly.
