### PR TITLE
Fix ESLint 5 deprecation warning

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,8 +1,7 @@
 {
   "parserOptions": {
-    "ecmaVersion": 8,
+    "ecmaVersion": 9,
     "ecmaFeatures": {
-      "experimentalObjectRestSpread": true,
       "jsx": true
     },
     "sourceType": "module"


### PR DESCRIPTION
Fix ESLint 5 deprecation warning of experimentalObjectRestSpread. Fixed #48