### PR TITLE
Detect react version to apply rules appropriately

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -9,7 +9,7 @@
 
   "settings": {
     "react": {
-      "version": "16.0"
+      "version": "detect"
     }
   },
 


### PR DESCRIPTION
This way, for example, `react/jsx-fragments` rule would be only applied if you use React < 16.2