### PR TITLE
add eslint-plugin-react-hooks & accompanying rules

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -9,7 +9,7 @@
 
   "settings": {
     "react": {
-      "version": "detect"
+      "version": "latest"
     }
   },
 

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -14,7 +14,8 @@
   },
 
   "plugins": [
-    "react"
+    "react",
+    "react-hooks"
   ],
 
   "extends": [
@@ -31,6 +32,8 @@
     "react/no-unknown-property": "error",
     "react/no-unused-prop-types": "error",
     "react/prop-types": "error",
-    "react/react-in-jsx-scope": "error"
+    "react/react-in-jsx-scope": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-standard-react",
   "description": "JavaScript Standard Style React/JSX support - ESLint Shareable Config",
-  "version": "9.2.0",
+  "version": "10.0.0",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",
@@ -18,6 +18,10 @@
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
     "tape": "^5.0.1"
+  },
+  "peerDependencies": {
+    "eslint": ">=7.7.0",
+    "eslint-plugin-react": ">=7.20.6"
   },
   "homepage": "https://github.com/feross/eslint-config-standard-react",
   "keywords": [
@@ -50,10 +54,6 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "peerDependencies": {
-    "eslint": ">=7.7.0",
-    "eslint-plugin-react": ">=7.20.6"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/feross/eslint-config-standard-react.git"

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "url": "https://github.com/feross/eslint-config-standard-react/issues"
   },
   "dependencies": {
-    "eslint-config-standard-jsx": "^8.0.0"
+    "eslint-config-standard-jsx": "^8.1.0"
   },
   "devDependencies": {
-    "eslint": "^6.2.2",
-    "eslint-plugin-react": "^7.6.1",
-    "tape": "^4.8.0"
+    "eslint": "^7.7.0",
+    "eslint-plugin-react": "^7.20.6",
+    "eslint-plugin-react-hooks": "^4.1.0",
+    "tape": "^5.0.1"
   },
   "homepage": "https://github.com/feross/eslint-config-standard-react",
   "keywords": [
@@ -50,8 +51,8 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "eslint": ">=6.2.2",
-    "eslint-plugin-react": ">=7.6.1"
+    "eslint": ">=7.7.0",
+    "eslint-plugin-react": ">=7.20.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This is a cleaned-up version of https://github.com/standard/eslint-config-standard-react/pull/62 that does _not_ check in `node_modules` as requested by @feross in https://github.com/standard/eslint-config-standard-react/pull/62#issuecomment-533818035.

Added `eslint-plugin-react-hooks` to `package.json` and added the [associated rules](https://reactjs.org/docs/hooks-rules.html) to `eslintrc.json`. 

**Is there anything you'd like reviewers to focus on?**

In the original PR @MatanBobi referenced the discussion in the original [issue](https://github.com/standard/eslint-config-standard-react/issues/57) about the `"react-hooks/exhaustive-deps"` rule being set to `"warn"` (Facebook's suggested setting) potentially being incompatible with the Standard approach. While this PR went with`"warn"` I can gladly change it to `"error"` as [suggested](https://github.com/standard/eslint-config-standard-react/issues/57#issuecomment-536028240) by @orpheus.
